### PR TITLE
Organized definition output

### DIFF
--- a/src/components/definitions.jsx
+++ b/src/components/definitions.jsx
@@ -37,7 +37,7 @@ export default function Definitions({ data }) {
         {defs.map(
           (def, index) =>
             index < defsVisible && (
-              <>
+              <div key={index} className="rounded">
                 {def.isTitle && (
                   <div
                     className="d-flex rounded "
@@ -48,31 +48,29 @@ export default function Definitions({ data }) {
                     </h4>
                   </div>
                 )}
-                <div key={index} className="rounded">
-                  <div
-                    onMouseEnter={() => setHovering(index)}
-                    onMouseLeave={() => setHovering(-1)}
-                    className="card-body p-3 rounded border border-dark"
-                    style={
-                      hovering === index
-                        ? { backgroundColor: 'var(--bs-dark)' }
-                        : { backgroundColor: 'var(--bs-darker)' }
-                    }
-                  >
-                    <div className="d-flex font-weight-bold font">
-                      <div
-                        className="mr-3"
-                        style={{ fontSize: '1.20rem', minWidth: '30px' }}
-                      >
-                        {index + 1}.
-                      </div>
-                      <div className="cap-first definition-text">
-                        {def.definition.toString()}.
-                      </div>
+                <div
+                  onMouseEnter={() => setHovering(index)}
+                  onMouseLeave={() => setHovering(-1)}
+                  className="card-body p-3 rounded border border-dark"
+                  style={
+                    hovering === index
+                      ? { backgroundColor: 'var(--bs-dark)' }
+                      : { backgroundColor: 'var(--bs-darker)' }
+                  }
+                >
+                  <div className="d-flex font-weight-bold font">
+                    <div
+                      className="mr-3"
+                      style={{ fontSize: '1.20rem', minWidth: '30px' }}
+                    >
+                      {index + 1}.
+                    </div>
+                    <div className="cap-first definition-text">
+                      {def.definition.toString()}.
                     </div>
                   </div>
                 </div>
-              </>
+              </div>
             ),
         )}
       </div>


### PR DESCRIPTION
### Changes I made:

1. Sorted  and organized the definition results by 'part of speech'.
2. Made various small styling changes to the definition output.

With this commit I was mostly concerned with the output organization. I'm not dead set or fully finished on the styling so let me know what you like or don't like. Its definitely an improvement though.

One annoying thing about the data is that the definitions are not organized by relevance at all. So we sometimes end up getting some of the more obscure definitions at the top, oh well I guess. Most words that aren't super basic and common only have like 1 or a few definitions anyway.

<img width="1232" alt="Screen Shot 2023-05-25 at 23 48 44" src="https://github.com/anhoop89/final_frontend_sp2023/assets/35203283/99988990-ba86-48ea-beb6-996d02bfed60">

<img width="1116" alt="Screen Shot 2023-05-26 at 00 02 15" src="https://github.com/anhoop89/final_frontend_sp2023/assets/35203283/49e5b592-b06d-45b3-b61b-32ac214c5761">

